### PR TITLE
Fix typo in <CronSchedule as Schedule>::next().

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -68,7 +68,7 @@ impl Schedule for CronSchedule {
             }
 
             // Find the next applicable day
-            while !self.days_of_month.is_empty() && !self.days_of_week.is_empty() {
+            while !self.days_of_month.is_empty() || !self.days_of_week.is_empty() {
                 if !self.days_of_month.is_empty() && self.days_of_month.contains(&r.day()) {
                     break;
                 }


### PR DESCRIPTION
The test was failing before this and it passes now.

Before:

    running 1 test
    test schedule::test::test_standard ... FAILED

    failures:

    ---- schedule::test::test_standard stdout ----
    thread 'schedule::test::test_standard' panicked at 'assertion failed: `(left == right)` (left: `1`, right: `3`)', src/schedule.rs:219

Now:

    running 1 test
    test schedule::test::test_standard ... ok

    test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured

Let me know if I missed anything!